### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A site that can automatically track your progress and explore events + user gene
 
 ## How to Access
 
-I host a copy of this site on [BTD6APIExplorer.github.io](BTD6APIExplorer.github.io)!
+I host a copy of this site on [BTD6APIExplorer.github.io](https://btd6apiexplorer.github.io)!


### PR DESCRIPTION
[The original link](https://github.com/HalfHydra/BTD6-API-Explorer/blob/ff6cd394db39819322db0eb445f3757ac3b087f7/README.md#how-to-access) `BTD6APIExplorer.github.io` was missing the `https://` protocol and redirected user to a 404 error page.

This PR updates the link to https://btd6apiexplorer.github.io, which works correctly.