### PR TITLE
Fix image overflow issue in Chromium-based browsers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -606,7 +606,7 @@ function generateFrontPage(){
     let siteImageScrollOverlayText = createEl('p', { classList: ['font-gardenia'], style: {fontSize: "20px", lineHeight: "1.5"}, innerHTML: 'Click on the images to access the sites!' });
     siteImageScrollLeft.appendChild(siteImageScrollOverlayText);
 
-    let siteImageScrollImage = createEl('img', { classList: ['site-image-scroll'], style: { borderRadius: "10px", boxShadow: "0 0 10px rgba(0, 0, 0, 0.5)", transition: "background-image 0.5s ease-in-out"}});
+    let siteImageScrollImage = createEl('img', { classList: ['site-image-scroll'], style: { borderRadius: "10px", boxShadow: "0 0 10px rgba(0, 0, 0, 0.5)", transition: "background-image 0.5s ease-in-out", width: "400px"}});
     siteImageScroll.appendChild(siteImageScrollImage);
 
     let sitePageDots = createEl('div', { classList: ['d-flex', 'jc-center'], style: {paddingTop: "20px"}});


### PR DESCRIPTION
This should fix the issue in Chromium-based browsers, as shown in the images below.

I tested it in Chromium-based browsers (Chrome, Edge, Opera, Vivaldi) and Firefox and it seems to work as intended.

<table>
  <tr>
    <th style="text-align:center;">Before</th>
    <th style="text-align:center;">After</th>
  </tr>
  <tr>
    <td style="text-align:center; vertical-align: top;">
      <img src="https://github.com/user-attachments/assets/48aa1130-6fbd-4bdf-865c-4bfb14fa6896" alt="Chromium before" width="400" height="192" style="max-width:100%; height:auto;" />
    </td>
    <td style="text-align:center; vertical-align: top;">
      <img src="https://github.com/user-attachments/assets/12d51a34-29ff-4fc9-80dd-87fa7d4a4901" alt="Chromium after" width="400" height="192" style="max-width:100%; height:auto;" />
    </td>
  </tr>
</table>